### PR TITLE
Changed _cnt to set content value using a NodeValidatorBuilder.

### DIFF
--- a/lib/src/popover.dart
+++ b/lib/src/popover.dart
@@ -21,13 +21,13 @@ class Popover extends Tooltip {
   Popover(Element element, {bool animation, String placement(Element elem), 
   String selector, String template, String trigger, String title(Element elem), 
   String content(Element elem), int delay, int showDelay, 
-  int hideDelay, bool html, container}) : 
+  int hideDelay, bool html, container, NodeValidatorBuilder htmlValidator}) : 
   this.template = _data(template, element, 'template', _DEFAULT_TEMPLATE),
   this.trigger  = _data(trigger,  element, 'trigger',  'click'),
   this._content = p.fallback(content, () => (Element elem) => elem.attributes['data-content']),
   super(element, animation: animation, placement: placement, selector: selector, 
   title: title, delay: delay, showDelay: showDelay, hideDelay: hideDelay, 
-  html: html, container: container, template: template);
+  html: html, container: container, htmlValidator: htmlValidator, template: template);
   
   /** Retrieve the wired Popover object from an element. If there is no wired
    * Popover object, a new one will be created.

--- a/lib/src/tooltip.dart
+++ b/lib/src/tooltip.dart
@@ -8,8 +8,7 @@ class Tooltip extends Base {
   static const String _NAME = 'tooltip';
   static const String _DEFAULT_TEMPLATE = 
       '<div class="tooltip"><div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>';
-  final NodeValidatorBuilder _htmlValidator=new NodeValidatorBuilder.common()
-    ..allowElement('a', attributes: ['href']);
+  final NodeValidatorBuilder _htmlValidator;
   
   /** Construct a tooltip component and wire it to [element].
    * 
@@ -38,17 +37,18 @@ class Tooltip extends Base {
    */
   Tooltip(Element element, {bool animation, String placement(Element elem), 
   String selector, String template, String trigger, String title(Element elem), 
-  int delay, int showDelay, int hideDelay, bool html, container}) : 
-  this.animation  = _bool(animation, element, 'animation', true),
-  this.html       = _bool(html,      element, 'html',      false),
-  this.showDelay  = _int(showDelay, element, 'show-delay', _int(delay, element, 'delay', 0)),
-  this.hideDelay  = _int(hideDelay, element, 'hide-delay', _int(delay, element, 'delay', 0)),
-  this.selector   = _data(selector,  element, 'selector'),
-  this.template   = _data(template,  element, 'template', _DEFAULT_TEMPLATE),
-  this.trigger    = _data(trigger,   element, 'trigger',  'hover focus'),
-  this.container  = _data(container, element, 'container'),
-  this._title     = p.fallback(title,     () => (Element elem) => elem.attributes['data-title']),
-  this._placement = p.fallback(placement, () => (Element elem) => elem.attributes['data-placement']),
+  int delay, int showDelay, int hideDelay, bool html, container, NodeValidatorBuilder htmlValidator}) : 
+  this.animation      = _bool(animation, element, 'animation', true),
+  this.html           = _bool(html,      element, 'html',      false),
+  this.showDelay      = _int(showDelay, element, 'show-delay', _int(delay, element, 'delay', 0)),
+  this.hideDelay      = _int(hideDelay, element, 'hide-delay', _int(delay, element, 'delay', 0)),
+  this.selector       = _data(selector,  element, 'selector'),
+  this.template       = _data(template,  element, 'template', _DEFAULT_TEMPLATE),
+  this.trigger        = _data(trigger,   element, 'trigger',  'hover focus'),
+  this.container      = _data(container, element, 'container'),
+  this._title         = p.fallback(title,     () => (Element elem) => elem.attributes['data-title']),
+  this._placement     = p.fallback(placement, () => (Element elem) => elem.attributes['data-placement']),
+  this._htmlValidator = htmlValidator,
   super(element, _NAME) {
     
     for (String t in this.trigger.split(' ')) {


### PR DESCRIPTION
Changed _cnt to set content value using a NodeValidatorBuilder to allow hyperlinks inside content. With current implementation, Dart sanitizes href attributes inside popover's content.
