### PR TITLE
Fixed an issue affecting popovers in dart2js code

### DIFF
--- a/lib/src/tooltip.dart
+++ b/lib/src/tooltip.dart
@@ -183,7 +183,7 @@ class Tooltip extends Base {
     if (container != null)
       $(tip).appendTo(container);
     else
-      $element.after(tip);
+      $element.after('body');
     
     final Rectangle pos = _position;
     final int actualWidth = tip.offsetWidth;


### PR DESCRIPTION
I found that ($element.after(tip);) does not work in dart2js for popovers. I changed it to ($element.after('body');) and it works fine.
