### PR TITLE
The dismiss button of an Alert does not works into a component with a Sh...

### DIFF
--- a/lib/src/alert.dart
+++ b/lib/src/alert.dart
@@ -82,5 +82,12 @@ class Alert extends Base {
     
     $document().on('click.alert.data-api', _closeHandler, selector: _DISMISS_SELECTOR);
   }
-  
+
+  /** Register to use Alert into a ShadowDom
+   *  In your component (likes Polymer or Angular) overide the method void onShadowRoot(ShadowRoot shadowRoot)
+   *  and initialize the Alert compoment ( Alert.useInShadowDom( shadowRoot) 
+   */
+  static void useInShadowDom( ShadowRoot shadowRoot) {
+    $document(shadowRoot).on('click.alert.data-api', _closeHandler, selector: Alert._DISMISS_SELECTOR);
+  }  
 }


### PR DESCRIPTION
In this discussion http://stackoverflow.com/questions/20420189/rikulo-bootjack-polymerdart 
You suggest to wire the element into the shadow dom. I do it for the tooltip but it doesn't work for Alert.

I suggest to add an initialization method for shadow dom. It works for Alert but this method can be used on others components too.
Open for discuss about this solution.

Regards.
